### PR TITLE
Require xmlsec1 instead of xmlsec1-gnutls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1107,7 +1107,7 @@ AC_MSG_RESULT($aqebics_datadir)
 if test "$with_aqebics" = "yes"; then
   AC_MSG_CHECKING(for build requirements needed by EBICS backend)
   AC_MSG_RESULT()
-  PKG_CHECK_MODULES(XMLSEC,  [xmlsec1-gnutls >= 1.0.0])
+  PKG_CHECK_MODULES(XMLSEC,  [xmlsec1 >= 1.0.0])
   PKG_CHECK_MODULES(LIBXML,  [libxml-2.0])
   PKG_CHECK_MODULES(LIBXSLT, [libxslt])
   AQEBICS_CFLAGS="$XMLSEC_CFLAGS $LIBXML_CFLAGS $LIBXSLT_CFLAGS"


### PR DESCRIPTION
AqBanking uses only xmlSecTransformInclC14NId from xmlsec1 and nothing
from xmlsec1-gnutls, so don't require the latter one.

In some configurations, compilers even optimize out xmlsec1-gnutls and
link libaqbaning.so to xmlsec1 only.